### PR TITLE
Satisfy iterator interface by fixing `IteratorSize`

### DIFF
--- a/src/PicoSAT.jl
+++ b/src/PicoSAT.jl
@@ -294,5 +294,6 @@ function Base.iterate(it::PicoSolIterator, state=nothing)
     end
 end
 
-IteratorSize(it::PicoSolIterator) = Base.SizeUnknown()
+IteratorSize(::Type{PicoSolIterator}) = Base.SizeUnknown()
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,6 +119,10 @@ using Test
     @test collect(PicoSAT.itersolve(clauses2,vars=nvars2)) == Any[]
     @test collect(PicoSAT.itersolve(clauses3, vars=3)) == Any[[-1, -2, -3], [-1, -2, 3]]
 
+    # iterator interface
+    @test map(identity, Iterators.map(identity, PicoSAT.itersolve(clauses1))) ==
+        collect(PicoSAT.itersolve(clauses1))
+
     # Armin Biere, "Using High Performance SAT and QBF Solvers", presentation
     # given 2011-01-24, pp. 23-48,
     # http://fmv.jku.at/biere/talks/Biere-TPTPA11.pdf


### PR DESCRIPTION
Currently, the `IteratorSize` method for `PicoSolIterator` is implemented incorrectly. This prevents it from being wrapped in other iterators, such as a generator. The interface redirects the type of values passed to `IteratorSize`, so types implementing the interface should be defined for `Type{PicoSolIterator}` instead.

### Before

```julia
julia> map(identity, Iterators.map(identity, itersolve([1])))
ERROR: MethodError: no method matching length(::PicoSAT.PicoSolIterator)
...
```

### After

```julia
julia> map(identity, Iterators.map(identity, itersolve([1])))
1-element Vector{Vector{Int64}}:
 [1]
```

p.s. I am using PicoSAT as a dependency and would be grateful for a v0.4.1 release with this change :)